### PR TITLE
bumped chia-blockchain version to 1.1.5

### DIFF
--- a/farmer/Dockerfile
+++ b/farmer/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7
 
-RUN pip install --extra-index-url https://hosted.chia.net/simple/ chia-blockchain==1.1.4 miniupnpc==2.1
+RUN pip install --extra-index-url https://hosted.chia.net/simple/ chia-blockchain==1.1.5 miniupnpc==2.1
 
 COPY keyfile farmer.sh /root/
 

--- a/plotter/Dockerfile
+++ b/plotter/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7
 
-RUN pip install --extra-index-url https://hosted.chia.net/simple/ chia-blockchain==1.1.4 miniupnpc==2.1
+RUN pip install --extra-index-url https://hosted.chia.net/simple/ chia-blockchain==1.1.5 miniupnpc==2.1
 
 RUN chia init
 


### PR DESCRIPTION
Hey,

I've run the update bumped the version locally yesterday and had no problems so far.

1.1.5 is a hot-fix in order to handle negative transaction values and farmers running older versions will have 33% of their blocks rejected

Cheers